### PR TITLE
Fix El Pais

### DIFF
--- a/request-blocker.js
+++ b/request-blocker.js
@@ -1,3 +1,3 @@
 chrome.webRequest.onBeforeRequest.addListener(function() {
   return { cancel: true };
-}, { urls: ["*://*/js/epd_sw*", "*://*/js/all*"] }, ["blocking"] );
+}, { urls: ["*://*/js/*", "*://*/js/all*"] }, ["blocking"] );


### PR DESCRIPTION
They changed the location of their JS file. Now seems that it's located in `/js/\d+.js`. This PR could be improved by only blocking files that match that format instead of all the js files under the js folder.